### PR TITLE
Fix image.Decode() only reading 4KB, Change At() and ColorModel() to NRGBA

### DIFF
--- a/image.go
+++ b/image.go
@@ -82,7 +82,7 @@ type img struct {
 }
 
 func (i *img) ColorModel() color.Model {
-	return color.RGBA64Model
+	return color.NRGBAModel
 }
 
 func (i *img) Bounds() image.Rectangle {

--- a/image.go
+++ b/image.go
@@ -92,11 +92,11 @@ func (i *img) Bounds() image.Rectangle {
 func (i *img) At(x, y int) color.Color {
 	arrPsn := i.pitch*y + i.stride*x
 	d := readBits(i.buf[arrPsn:], i.h.pixelFormat.rgbBitCount)
+	r := uint8((d & i.h.pixelFormat.rBitMask) >> i.rBit)
+	g := uint8((d & i.h.pixelFormat.gBitMask) >> i.gBit)
+	b := uint8((d & i.h.pixelFormat.bBitMask) >> i.bBit)
 	a := uint8((d & i.h.pixelFormat.aBitMask) >> i.aBit)
-	r := uint8(((d & i.h.pixelFormat.rBitMask) >> i.rBit) * uint32(a) / 255)
-	g := uint8(((d & i.h.pixelFormat.gBitMask) >> i.gBit) * uint32(a) / 255)
-	b := uint8(((d & i.h.pixelFormat.bBitMask) >> i.bBit) * uint32(a) / 255)
-	return color.RGBA{r, g, b, a}
+	return color.NRGBA{r, g, b, a}
 }
 
 func Decode(r io.Reader) (image.Image, error) {

--- a/image.go
+++ b/image.go
@@ -92,10 +92,10 @@ func (i *img) Bounds() image.Rectangle {
 func (i *img) At(x, y int) color.Color {
 	arrPsn := i.pitch*y + i.stride*x
 	d := readBits(i.buf[arrPsn:], i.h.pixelFormat.rgbBitCount)
-	r := uint8((d & i.h.pixelFormat.rBitMask) >> i.rBit)
-	g := uint8((d & i.h.pixelFormat.gBitMask) >> i.gBit)
-	b := uint8((d & i.h.pixelFormat.bBitMask) >> i.bBit)
 	a := uint8((d & i.h.pixelFormat.aBitMask) >> i.aBit)
+	r := uint8(((d & i.h.pixelFormat.rBitMask) >> i.rBit) * uint32(a) / 255)
+	g := uint8(((d & i.h.pixelFormat.gBitMask) >> i.gBit) * uint32(a) / 255)
+	b := uint8(((d & i.h.pixelFormat.bBitMask) >> i.bBit) * uint32(a) / 255)
 	return color.RGBA{r, g, b, a}
 }
 

--- a/image.go
+++ b/image.go
@@ -115,7 +115,7 @@ func Decode(r io.Reader) (image.Image, error) {
 
 	pitch := (h.width*h.pixelFormat.rgbBitCount + 7) / 8
 	buf := make([]byte, pitch*h.height)
-	if _, err := r.Read(buf); err != nil {
+	if _, err := io.ReadFull(r, buf); err != nil {
 		return nil, fmt.Errorf("reading image: %v", err)
 	}
 	stride := h.pixelFormat.rgbBitCount / 8


### PR DESCRIPTION
Hey, thank you for the library.

I've found the following issue: the lib works fine if `dds.Decode()` is used, but using `image.Decode()` stops reading the actual image data after 4 KB, and leaves the rest of it as `{0, 0, 0, 0}`.

The reason behind this is that when `image.Decode()` is used `io.Reader` is converted into `bufio.Reader` that has default buffer size of 4 KB. Using `Reader.Read()`, they way you are doing now, only reads data up to that buffer size. In order to fill the whole buffer your created for the image you need to use `io.ReadFull()` instead.